### PR TITLE
Adds persistence to the Github example

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,20 @@
     $(function () {
       var $editor = $("#the_editor");
       var $previewer = $("#the_previewer")
+
+      // Browsers that support localstorage should persist any changes
+      if (typeof localStorage !== "undefined") {
+        var persistedValue = localStorage.getItem("editor");
+
+        if (persistedValue) {
+          $editor.val(persistedValue);
+        }
+
+        $editor.bind("keyup change", function () {
+          localStorage.setItem("editor", $editor.val());
+        });
+      }
+
       $editor.crevasse({
         previewer: $previewer
       });


### PR DESCRIPTION
I implemented a really simple persistence layer on top of the example page that utilizes `localStorage`. It should fail gracefully in browsers that don't support it. The only downside I can see is that there's currently no way to reset the contents to the original copy.
