### PR TITLE
Fixes Rainbow.js in a way that doesn't suck

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -9,8 +9,7 @@ COFFEE_FILES = [
   "events.coffee",
   "editor.coffee",
   "previewer.coffee",
-  "utils.coffee",
-  "rainbow_patch"
+  "utils.coffee"
 ]
 
 task "build", "Package Crevasse for distribution", ->

--- a/README.md
+++ b/README.md
@@ -132,12 +132,6 @@ $("#your_editor").val("Some new value").trigger("change");
 * Add some Markdown-specific editing improvements like adding a bullet automatically
 if you hit enter while already in a list.
 
-## Caveats
-
-For compatibility reasons, Crevasse disables Rainbow.js' auto-highlighting
-functionality. This means that if you're using Rainbow.js elsewhere in your app,
-you'll need to initialize it yourself on specific elements.
-
 ## Contributing
 
 1. Fork and clone your fork

--- a/src/coffee/previewer.coffee
+++ b/src/coffee/previewer.coffee
@@ -54,6 +54,10 @@ class Crevasse.Previewer
 
   render: (text, caretPosition = null) ->
     @$previewer.html @_parse(text)
+
+    # Stop's Rainbow.js from double-highlighting
+    @$previewer.find("code").addClass("rainbow") if Rainbow?
+
     if caretPosition?
       offset = @_determineOffset text.substr(0, caretPosition)
       offset = 0 if offset < 0

--- a/src/coffee/rainbow_patch.coffee
+++ b/src/coffee/rainbow_patch.coffee
@@ -1,6 +1,0 @@
-# Disables Rainbow's global syntax highlighting on page load, which for some
-# reason double-highlights any code in the previewer
-if window.removeEventListener
-  window.removeEventListener("load", Rainbow.color)
-else
-  window.detachEvent("onload", Rainbow.color)


### PR DESCRIPTION
This fix is better than the last workaround. Doesn't screw around with people's rainbow install
